### PR TITLE
Add MemoryIA persistent memory system with SQLite and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# computacion_movil_rep01
+# MemoryIA
+
+Este proyecto implementa un sistema base de **memoria persistente** para agentes de IA usando Python y SQLite. Su objetivo es reducir la pérdida de contexto entre ejecuciones y facilitar que un agente recuerde:
+
+- en qué punto quedó,
+- qué cambios realizó,
+- qué tareas pendientes tiene,
+- y cuál fue su último estado conocido.
+
+## Características
+
+- Persistencia local con SQLite (`memoria_agentes.db`).
+- Registro de eventos por `agente_id`.
+- Recuperación del último contexto disponible.
+- Consulta de historial reciente.
+- Búsqueda por término dentro del contenido almacenado.
+
+## Estructura principal
+
+- `memoryia.py`: clase principal `MemoryIA` y una demo ejecutable.
+
+## Requisitos
+
+- Python 3.9 o superior.
+
+## Ejecución
+
+```bash
+python memoryia.py
+```
+
+Al ejecutar el script se insertan eventos de ejemplo, se imprime el último contexto, el historial y una búsqueda simple.
+
+## Integración sugerida en un agente
+
+1. Al iniciar un agente, llamar `obtener_ultimo_contexto(agente_id)`.
+2. Durante la ejecución, registrar acciones con `registrar_evento(...)`.
+3. En puntos críticos, guardar resúmenes como `tipo="checkpoint"`.
+4. Antes de finalizar, registrar estado final y tareas pendientes.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,21 @@
 # MemoryIA
 
-Este proyecto implementa un sistema base de **memoria persistente** para agentes de IA usando Python y SQLite. Su objetivo es reducir la pérdida de contexto entre ejecuciones y facilitar que un agente recuerde:
-
-- en qué punto quedó,
-- qué cambios realizó,
-- qué tareas pendientes tiene,
-- y cuál fue su último estado conocido.
+**MemoryIA** es un sistema de memoria persistente para agentes de IA con ejecución robusta y registro en segundo plano. Está diseñado para reducir pérdida de contexto, recuperar estado y mantener trazabilidad de cambios y tareas.
 
 ## Características
 
 - Persistencia local con SQLite (`memoria_agentes.db`).
-- Registro de eventos por `agente_id`.
-- Recuperación del último contexto disponible.
-- Consulta de historial reciente.
-- Búsqueda por término dentro del contenido almacenado.
+- Registro por `agente_id` de eventos, estados, cambios y tareas.
+- Recuperación del último contexto, historial y búsqueda por término.
+- Motor asíncrono (`MotorPersistente`) para guardar eventos en segundo plano.
+- Interfaz de alto nivel (`InterfazInteligente`) para integración rápida.
 
 ## Estructura principal
 
-- `memoryia.py`: clase principal `MemoryIA` y una demo ejecutable.
+- `memoryia.py`
+  - `MemoryIA`: capa de persistencia SQLite.
+  - `MotorPersistente`: proceso/hilo para escritura asíncrona.
+  - `InterfazInteligente`: capa de interacción simplificada.
 
 ## Requisitos
 
@@ -29,11 +27,9 @@ Este proyecto implementa un sistema base de **memoria persistente** para agentes
 python memoryia.py
 ```
 
-Al ejecutar el script se insertan eventos de ejemplo, se imprime el último contexto, el historial y una búsqueda simple.
+La demo crea eventos, los persiste en segundo plano y luego imprime resumen, historial y resultados de búsqueda.
 
-## Integración sugerida en un agente
+## Notas de alcance
 
-1. Al iniciar un agente, llamar `obtener_ultimo_contexto(agente_id)`.
-2. Durante la ejecución, registrar acciones con `registrar_evento(...)`.
-3. En puntos críticos, guardar resúmenes como `tipo="checkpoint"`.
-4. Antes de finalizar, registrar estado final y tareas pendientes.
+- MemoryIA no se autoautoriza en GitHub ni ejecuta acciones autónomas externas sin un integrador que lo programe explícitamente.
+- Para integraciones con APIs externas, se recomienda manejar credenciales mediante variables de entorno y permisos mínimos.

--- a/memoryia.py
+++ b/memoryia.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from queue import Empty, Queue
 from typing import Iterable
 
 
@@ -25,24 +28,26 @@ class MemoryIA:
 
     def __init__(self, db_path: str = "memoria_agentes.db") -> None:
         self.db_path = Path(db_path)
-        self.conn = sqlite3.connect(self.db_path)
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
         self.conn.row_factory = sqlite3.Row
+        self._lock = threading.Lock()
         self._inicializar_db()
 
     def _inicializar_db(self) -> None:
-        self.conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS memoria (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                agente_id TEXT NOT NULL,
-                tipo TEXT NOT NULL,
-                contenido TEXT NOT NULL,
-                metadata TEXT DEFAULT '{}',
-                creado_en TEXT NOT NULL
+        with self._lock:
+            self.conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS memoria (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    agente_id TEXT NOT NULL,
+                    tipo TEXT NOT NULL,
+                    contenido TEXT NOT NULL,
+                    metadata TEXT DEFAULT '{}',
+                    creado_en TEXT NOT NULL
+                )
+                """
             )
-            """
-        )
-        self.conn.commit()
+            self.conn.commit()
 
     def registrar_evento(
         self,
@@ -52,86 +57,152 @@ class MemoryIA:
         metadata: str = "{}",
     ) -> int:
         creado_en = datetime.now(timezone.utc).isoformat()
-        cursor = self.conn.execute(
-            """
-            INSERT INTO memoria (agente_id, tipo, contenido, metadata, creado_en)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            (agente_id, tipo, contenido, metadata, creado_en),
-        )
-        self.conn.commit()
-        return int(cursor.lastrowid)
+        with self._lock:
+            cursor = self.conn.execute(
+                """
+                INSERT INTO memoria (agente_id, tipo, contenido, metadata, creado_en)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (agente_id, tipo, contenido, metadata, creado_en),
+            )
+            self.conn.commit()
+            return int(cursor.lastrowid)
 
     def obtener_ultimo_contexto(self, agente_id: str) -> RegistroMemoria | None:
-        cursor = self.conn.execute(
-            """
-            SELECT *
-            FROM memoria
-            WHERE agente_id = ?
-            ORDER BY id DESC
-            LIMIT 1
-            """,
-            (agente_id,),
-        )
-        row = cursor.fetchone()
+        with self._lock:
+            cursor = self.conn.execute(
+                """
+                SELECT *
+                FROM memoria
+                WHERE agente_id = ?
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (agente_id,),
+            )
+            row = cursor.fetchone()
         if not row:
             return None
         return RegistroMemoria(**dict(row))
 
     def historial(self, agente_id: str, limite: int = 20) -> Iterable[RegistroMemoria]:
-        cursor = self.conn.execute(
-            """
-            SELECT *
-            FROM memoria
-            WHERE agente_id = ?
-            ORDER BY id DESC
-            LIMIT ?
-            """,
-            (agente_id, limite),
-        )
-        for row in cursor.fetchall():
+        with self._lock:
+            cursor = self.conn.execute(
+                """
+                SELECT *
+                FROM memoria
+                WHERE agente_id = ?
+                ORDER BY id DESC
+                LIMIT ?
+                """,
+                (agente_id, limite),
+            )
+            rows = cursor.fetchall()
+        for row in rows:
             yield RegistroMemoria(**dict(row))
 
     def buscar(self, agente_id: str, termino: str, limite: int = 10) -> Iterable[RegistroMemoria]:
-        cursor = self.conn.execute(
-            """
-            SELECT *
-            FROM memoria
-            WHERE agente_id = ? AND contenido LIKE ?
-            ORDER BY id DESC
-            LIMIT ?
-            """,
-            (agente_id, f"%{termino}%", limite),
-        )
-        for row in cursor.fetchall():
+        with self._lock:
+            cursor = self.conn.execute(
+                """
+                SELECT *
+                FROM memoria
+                WHERE agente_id = ? AND contenido LIKE ?
+                ORDER BY id DESC
+                LIMIT ?
+                """,
+                (agente_id, f"%{termino}%", limite),
+            )
+            rows = cursor.fetchall()
+        for row in rows:
             yield RegistroMemoria(**dict(row))
 
     def cerrar(self) -> None:
-        self.conn.close()
+        with self._lock:
+            self.conn.close()
+
+
+class MotorPersistente:
+    """Proceso en segundo plano para guardar eventos sin bloquear al agente."""
+
+    def __init__(self, memoria: MemoryIA, intervalo_segundos: float = 1.0) -> None:
+        self.memoria = memoria
+        self.intervalo_segundos = intervalo_segundos
+        self._cola: Queue[tuple[str, str, str, str]] = Queue()
+        self._detener = threading.Event()
+        self._hilo = threading.Thread(target=self._bucle, daemon=True)
+
+    def iniciar(self) -> None:
+        if not self._hilo.is_alive():
+            self._hilo.start()
+
+    def registrar_async(
+        self,
+        agente_id: str,
+        contenido: str,
+        tipo: str = "evento",
+        metadata: str = "{}",
+    ) -> None:
+        self._cola.put((agente_id, contenido, tipo, metadata))
+
+    def _bucle(self) -> None:
+        while not self._detener.is_set():
+            try:
+                agente_id, contenido, tipo, metadata = self._cola.get(timeout=self.intervalo_segundos)
+                self.memoria.registrar_evento(agente_id, contenido, tipo=tipo, metadata=metadata)
+                self._cola.task_done()
+            except Empty:
+                continue
+
+    def detener(self) -> None:
+        self._detener.set()
+        self._hilo.join(timeout=2)
+
+
+class InterfazInteligente:
+    """Interfaz de comandos para consultar y registrar memoria de forma robusta."""
+
+    def __init__(self, memoria: MemoryIA, motor: MotorPersistente) -> None:
+        self.memoria = memoria
+        self.motor = motor
+
+    def registrar(self, agente_id: str, contenido: str, tipo: str = "evento") -> None:
+        self.motor.registrar_async(agente_id, contenido, tipo)
+
+    def resumen(self, agente_id: str) -> str:
+        ultimo = self.memoria.obtener_ultimo_contexto(agente_id)
+        if not ultimo:
+            return "Sin contexto previo para este agente."
+        return f"Último: [{ultimo.tipo}] {ultimo.contenido} ({ultimo.creado_en})"
 
 
 def demo() -> None:
-    sistema = MemoryIA()
+    memoria = MemoryIA()
+    motor = MotorPersistente(memoria)
+    interfaz = InterfazInteligente(memoria, motor)
+
     agente = "agente-demo"
+    motor.iniciar()
 
-    print("=== Demo de Memoria Persistente para Agentes de IA ===")
-    sistema.registrar_evento(agente, "Inicio de sesión del agente", tipo="estado")
-    sistema.registrar_evento(agente, "Se modificó el módulo de autenticación", tipo="cambio")
-    sistema.registrar_evento(agente, "Pendiente: escribir pruebas unitarias", tipo="tarea")
+    interfaz.registrar(agente, "Inicio de sesión del agente", tipo="estado")
+    interfaz.registrar(agente, "Se modificó el módulo de autenticación", tipo="cambio")
+    interfaz.registrar(agente, "Pendiente: escribir pruebas unitarias", tipo="tarea")
 
-    ultimo = sistema.obtener_ultimo_contexto(agente)
-    if ultimo:
-        print(f"\nÚltimo contexto ({ultimo.tipo}): {ultimo.contenido}")
+    time.sleep(1.2)
+
+    print("=== Demo MemoryIA (modo persistente en segundo plano) ===")
+    print(interfaz.resumen(agente))
 
     print("\nHistorial reciente:")
-    for registro in sistema.historial(agente, limite=5):
+    for registro in memoria.historial(agente, limite=5):
         print(f"- [{registro.creado_en}] {registro.tipo}: {registro.contenido}")
 
     print("\nBúsqueda de 'pruebas':")
-    for registro in sistema.buscar(agente, "pruebas"):
+    for registro in memoria.buscar(agente, "pruebas"):
         print(f"- {registro.tipo}: {registro.contenido}")
 
-    sistema.cerrar()
+    motor.detener()
+    memoria.cerrar()
 
 
 if __name__ == "__main__":

--- a/memoryia.py
+++ b/memoryia.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass
+class RegistroMemoria:
+    id: int
+    agente_id: str
+    tipo: str
+    contenido: str
+    metadata: str
+    creado_en: str
+
+
+class MemoryIA:
+    """MemoryIA: sistema simple de memoria persistente para agentes de IA.
+
+    Usa SQLite para mantener eventos de contexto entre ejecuciones.
+    """
+
+    def __init__(self, db_path: str = "memoria_agentes.db") -> None:
+        self.db_path = Path(db_path)
+        self.conn = sqlite3.connect(self.db_path)
+        self.conn.row_factory = sqlite3.Row
+        self._inicializar_db()
+
+    def _inicializar_db(self) -> None:
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS memoria (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agente_id TEXT NOT NULL,
+                tipo TEXT NOT NULL,
+                contenido TEXT NOT NULL,
+                metadata TEXT DEFAULT '{}',
+                creado_en TEXT NOT NULL
+            )
+            """
+        )
+        self.conn.commit()
+
+    def registrar_evento(
+        self,
+        agente_id: str,
+        contenido: str,
+        tipo: str = "evento",
+        metadata: str = "{}",
+    ) -> int:
+        creado_en = datetime.now(timezone.utc).isoformat()
+        cursor = self.conn.execute(
+            """
+            INSERT INTO memoria (agente_id, tipo, contenido, metadata, creado_en)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (agente_id, tipo, contenido, metadata, creado_en),
+        )
+        self.conn.commit()
+        return int(cursor.lastrowid)
+
+    def obtener_ultimo_contexto(self, agente_id: str) -> RegistroMemoria | None:
+        cursor = self.conn.execute(
+            """
+            SELECT *
+            FROM memoria
+            WHERE agente_id = ?
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            (agente_id,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return None
+        return RegistroMemoria(**dict(row))
+
+    def historial(self, agente_id: str, limite: int = 20) -> Iterable[RegistroMemoria]:
+        cursor = self.conn.execute(
+            """
+            SELECT *
+            FROM memoria
+            WHERE agente_id = ?
+            ORDER BY id DESC
+            LIMIT ?
+            """,
+            (agente_id, limite),
+        )
+        for row in cursor.fetchall():
+            yield RegistroMemoria(**dict(row))
+
+    def buscar(self, agente_id: str, termino: str, limite: int = 10) -> Iterable[RegistroMemoria]:
+        cursor = self.conn.execute(
+            """
+            SELECT *
+            FROM memoria
+            WHERE agente_id = ? AND contenido LIKE ?
+            ORDER BY id DESC
+            LIMIT ?
+            """,
+            (agente_id, f"%{termino}%", limite),
+        )
+        for row in cursor.fetchall():
+            yield RegistroMemoria(**dict(row))
+
+    def cerrar(self) -> None:
+        self.conn.close()
+
+
+def demo() -> None:
+    sistema = MemoryIA()
+    agente = "agente-demo"
+
+    print("=== Demo de Memoria Persistente para Agentes de IA ===")
+    sistema.registrar_evento(agente, "Inicio de sesión del agente", tipo="estado")
+    sistema.registrar_evento(agente, "Se modificó el módulo de autenticación", tipo="cambio")
+    sistema.registrar_evento(agente, "Pendiente: escribir pruebas unitarias", tipo="tarea")
+
+    ultimo = sistema.obtener_ultimo_contexto(agente)
+    if ultimo:
+        print(f"\nÚltimo contexto ({ultimo.tipo}): {ultimo.contenido}")
+
+    print("\nHistorial reciente:")
+    for registro in sistema.historial(agente, limite=5):
+        print(f"- [{registro.creado_en}] {registro.tipo}: {registro.contenido}")
+
+    print("\nBúsqueda de 'pruebas':")
+    for registro in sistema.buscar(agente, "pruebas"):
+        print(f"- {registro.tipo}: {registro.contenido}")
+
+    sistema.cerrar()
+
+
+if __name__ == "__main__":
+    demo()


### PR DESCRIPTION
### Motivation

- Proveer un sistema simple de memoria persistente para agentes de IA para reducir pérdida de contexto entre ejecuciones. 
- Permitir registrar eventos, estados, cambios y tareas pendientes por `agente_id` y poder recuperarlos o buscarlos posteriormente. 
- Ofrecer una implementación ligera y local basada en SQLite que sea fácil de integrar en agentes existentes.

### Description

- Se añade `memoryia.py` que implementa la clase `MemoryIA` y el dataclass `RegistroMemoria` con métodos `registrar_evento`, `obtener_ultimo_contexto`, `historial`, `buscar` y `cerrar` para gestionar la memoria persistente. 
- `MemoryIA` inicializa una base de datos SQLite por defecto en `memoria_agentes.db` y crea la tabla `memoria` si no existe. 
- Se incluye una `demo()` ejecutable bajo `if __name__ == "__main__"` que inserta eventos de ejemplo y muestra el último contexto, historial y una búsqueda. 
- Se actualiza `README.md` (renombrado a "MemoryIA") con descripción del proyecto, características, estructura, requisitos y ejemplos de uso e integración.

### Testing

- No se añadieron ni ejecutaron pruebas automatizadas como parte de este cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_68dc913f58ec8324a17f5c691da98af8)