### PR TITLE
Crear FitMotion: app iOS de rutinas con fotogramas remotos

### DIFF
--- a/FitMotion.xcodeproj/project.pbxproj
+++ b/FitMotion.xcodeproj/project.pbxproj
@@ -1,0 +1,85 @@
+// !$*UTF8*$!
+{
+ archiveVersion = 1;
+ classes = {};
+ objectVersion = 77;
+ objects = {
+/* Begin PBXBuildFile section */
+		F71E947DCF41F30F77E91263 /* FitMotionApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E94E5AD51623C3EB100B35 /* FitMotionApp.swift */; };
+		F9390E089BDCDFAED8749398 /* Exercise.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2444527CA2944D5506BB08 /* Exercise.swift */; };
+		193A2778C44AFAAFBDC39A85 /* ExerciseCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F277C2821799BD4BDCDD4A89 /* ExerciseCatalog.swift */; };
+		6FCB678B11553142698EEB7C /* WorkoutStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A721D1B6DD5D094773F4488 /* WorkoutStore.swift */; };
+		5CA30FD907ACAE052669ACD4 /* ExerciseDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7046A4312CA950296EC294D2 /* ExerciseDetailView.swift */; };
+		C82DF630129FC9E1CDA5E348 /* ExerciseRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923A91C923F5AF59C775075E /* ExerciseRow.swift */; };
+		90D5851D13AB252439C19EAF /* ExploreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ECA152F66AFFCD39FFF539E /* ExploreView.swift */; };
+		AE73339A4BA01F55760FE9C1 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2AF47C8E5C9E88799938B5 /* HomeView.swift */; };
+		3103A3B5C636F66FEF34D110 /* RemoteExerciseMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30D42862000DA48C3B9E160D /* RemoteExerciseMedia.swift */; };
+		79CD11EC9A26386E67A579F2 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80B3DA07FC1B172A7A9A28B /* RootView.swift */; };
+		115E54E41A2BE59B652B0D1E /* RoutineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C8ABB6ACB6C20C64CF9E93 /* RoutineView.swift */; };
+		39F04E8A805A9D72083C36FC /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2A81E5788E8A7FF01442F11 /* Theme.swift */; };
+		BA8720616AE5648E51B173FA /* WorkoutPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D1D479DA21D18864A01B21 /* WorkoutPlayerView.swift */; };
+		596B9C8BB5C35C1346B67388 /* WorkoutStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2340A5C2DEFD6D74E40DD12D /* WorkoutStoreTests.swift */; };
+/* End PBXBuildFile section */
+/* Begin PBXFileReference section */
+		50E94E5AD51623C3EB100B35 /* FitMotionApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FitMotion/App/FitMotionApp.swift"; sourceTree = "<group>"; };
+		CF2444527CA2944D5506BB08 /* Exercise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FitMotion/Models/Exercise.swift"; sourceTree = "<group>"; };
+		F277C2821799BD4BDCDD4A89 /* ExerciseCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FitMotion/Services/ExerciseCatalog.swift"; sourceTree = "<group>"; };
+		1A721D1B6DD5D094773F4488 /* WorkoutStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FitMotion/ViewModels/WorkoutStore.swift"; sourceTree = "<group>"; };
+		7046A4312CA950296EC294D2 /* ExerciseDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FitMotion/Views/ExerciseDetailView.swift"; sourceTree = "<group>"; };
+		923A91C923F5AF59C775075E /* ExerciseRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FitMotion/Views/ExerciseRow.swift"; sourceTree = "<group>"; };
+		4ECA152F66AFFCD39FFF539E /* ExploreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FitMotion/Views/ExploreView.swift"; sourceTree = "<group>"; };
+		BF2AF47C8E5C9E88799938B5 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FitMotion/Views/HomeView.swift"; sourceTree = "<group>"; };
+		30D42862000DA48C3B9E160D /* RemoteExerciseMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FitMotion/Views/RemoteExerciseMedia.swift"; sourceTree = "<group>"; };
+		F80B3DA07FC1B172A7A9A28B /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FitMotion/Views/RootView.swift"; sourceTree = "<group>"; };
+		C7C8ABB6ACB6C20C64CF9E93 /* RoutineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FitMotion/Views/RoutineView.swift"; sourceTree = "<group>"; };
+		A2A81E5788E8A7FF01442F11 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FitMotion/Views/Theme.swift"; sourceTree = "<group>"; };
+		C3D1D479DA21D18864A01B21 /* WorkoutPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FitMotion/Views/WorkoutPlayerView.swift"; sourceTree = "<group>"; };
+		2340A5C2DEFD6D74E40DD12D /* WorkoutStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FitMotionTests/WorkoutStoreTests.swift"; sourceTree = "<group>"; };
+		A00000000000000000000001 /* FitMotion.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; path = FitMotion.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A00000000000000000000002 /* FitMotionTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = FitMotionTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+/* Begin PBXFrameworksBuildPhase section */
+		A10000000000000000000001 = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+		A10000000000000000000002 = {isa = PBXFrameworksBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXFrameworksBuildPhase section */
+/* Begin PBXGroup section */
+		A20000000000000000000001 = {isa = PBXGroup; children = (50E94E5AD51623C3EB100B35 /* FitMotionApp.swift */, CF2444527CA2944D5506BB08 /* Exercise.swift */, F277C2821799BD4BDCDD4A89 /* ExerciseCatalog.swift */, 1A721D1B6DD5D094773F4488 /* WorkoutStore.swift */, 7046A4312CA950296EC294D2 /* ExerciseDetailView.swift */, 923A91C923F5AF59C775075E /* ExerciseRow.swift */, 4ECA152F66AFFCD39FFF539E /* ExploreView.swift */, BF2AF47C8E5C9E88799938B5 /* HomeView.swift */, 30D42862000DA48C3B9E160D /* RemoteExerciseMedia.swift */, F80B3DA07FC1B172A7A9A28B /* RootView.swift */, C7C8ABB6ACB6C20C64CF9E93 /* RoutineView.swift */, A2A81E5788E8A7FF01442F11 /* Theme.swift */, C3D1D479DA21D18864A01B21 /* WorkoutPlayerView.swift */, 2340A5C2DEFD6D74E40DD12D /* WorkoutStoreTests.swift */, A20000000000000000000002 /* Products */); sourceTree = "<group>"; };
+		A20000000000000000000002 /* Products */ = {isa = PBXGroup; children = (A00000000000000000000001 /* FitMotion.app */, A00000000000000000000002 /* FitMotionTests.xctest */); name = Products; sourceTree = "<group>"; };
+/* End PBXGroup section */
+/* Begin PBXNativeTarget section */
+		A30000000000000000000001 /* FitMotion */ = {isa = PBXNativeTarget; buildConfigurationList = A60000000000000000000001; buildPhases = (A40000000000000000000001, A10000000000000000000001, A50000000000000000000001); buildRules = (); dependencies = (); name = FitMotion; productName = FitMotion; productReference = A00000000000000000000001; productType = "com.apple.product-type.application"; };
+		A30000000000000000000002 /* FitMotionTests */ = {isa = PBXNativeTarget; buildConfigurationList = A60000000000000000000002; buildPhases = (A40000000000000000000002, A10000000000000000000002, A50000000000000000000002); buildRules = (); dependencies = (A70000000000000000000001); name = FitMotionTests; productName = FitMotionTests; productReference = A00000000000000000000002; productType = "com.apple.product-type.bundle.unit-test"; };
+/* End PBXNativeTarget section */
+/* Begin PBXProject section */
+		A80000000000000000000001 /* Project object */ = {isa = PBXProject; attributes = {BuildIndependentTargetsInParallel = 1; LastSwiftUpdateCheck = 1600; LastUpgradeCheck = 1600; TargetAttributes = {A30000000000000000000001 = {CreatedOnToolsVersion = 16.0;}; A30000000000000000000002 = {CreatedOnToolsVersion = 16.0; TestTargetID = A30000000000000000000001;};};}; buildConfigurationList = A60000000000000000000003; compatibilityVersion = "Xcode 16.0"; developmentRegion = en; hasScannedForEncodings = 0; knownRegions = (en, Base); mainGroup = A20000000000000000000001; productRefGroup = A20000000000000000000002; projectDirPath = ""; projectRoot = ""; targets = (A30000000000000000000001, A30000000000000000000002); };
+/* End PBXProject section */
+/* Begin PBXResourcesBuildPhase section */
+		A50000000000000000000001 = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+		A50000000000000000000002 = {isa = PBXResourcesBuildPhase; buildActionMask = 2147483647; files = (); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXResourcesBuildPhase section */
+/* Begin PBXSourcesBuildPhase section */
+		A40000000000000000000001 = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (F71E947DCF41F30F77E91263 /* FitMotionApp.swift in Sources */, F9390E089BDCDFAED8749398 /* Exercise.swift in Sources */, 193A2778C44AFAAFBDC39A85 /* ExerciseCatalog.swift in Sources */, 6FCB678B11553142698EEB7C /* WorkoutStore.swift in Sources */, 5CA30FD907ACAE052669ACD4 /* ExerciseDetailView.swift in Sources */, C82DF630129FC9E1CDA5E348 /* ExerciseRow.swift in Sources */, 90D5851D13AB252439C19EAF /* ExploreView.swift in Sources */, AE73339A4BA01F55760FE9C1 /* HomeView.swift in Sources */, 3103A3B5C636F66FEF34D110 /* RemoteExerciseMedia.swift in Sources */, 79CD11EC9A26386E67A579F2 /* RootView.swift in Sources */, 115E54E41A2BE59B652B0D1E /* RoutineView.swift in Sources */, 39F04E8A805A9D72083C36FC /* Theme.swift in Sources */, BA8720616AE5648E51B173FA /* WorkoutPlayerView.swift in Sources */, ); runOnlyForDeploymentPostprocessing = 0; };
+		A40000000000000000000002 = {isa = PBXSourcesBuildPhase; buildActionMask = 2147483647; files = (596B9C8BB5C35C1346B67388 /* WorkoutStoreTests.swift in Sources */, ); runOnlyForDeploymentPostprocessing = 0; };
+/* End PBXSourcesBuildPhase section */
+/* Begin PBXTargetDependency section */
+		A70000000000000000000001 = {isa = PBXTargetDependency; target = A30000000000000000000001; targetProxy = A70000000000000000000002; };
+/* End PBXTargetDependency section */
+/* Begin PBXContainerItemProxy section */
+		A70000000000000000000002 = {isa = PBXContainerItemProxy; containerPortal = A80000000000000000000001; proxyType = 1; remoteGlobalIDString = A30000000000000000000001; remoteInfo = FitMotion; };
+/* End PBXContainerItemProxy section */
+/* Begin XCBuildConfiguration section */
+		B00000000000000000000001 = {isa = XCBuildConfiguration; buildSettings = {ALWAYS_SEARCH_USER_PATHS = NO; CLANG_ENABLE_MODULES = YES; IPHONEOS_DEPLOYMENT_TARGET = 17.0; SDKROOT = iphoneos; SWIFT_VERSION = 5.0;}; name = Debug; };
+		B00000000000000000000002 = {isa = XCBuildConfiguration; buildSettings = {ALWAYS_SEARCH_USER_PATHS = NO; CLANG_ENABLE_MODULES = YES; IPHONEOS_DEPLOYMENT_TARGET = 17.0; SDKROOT = iphoneos; SWIFT_VERSION = 5.0;}; name = Release; };
+		B00000000000000000000003 = {isa = XCBuildConfiguration; buildSettings = {ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES; CODE_SIGN_STYLE = Automatic; CURRENT_PROJECT_VERSION = 1; GENERATE_INFOPLIST_FILE = YES; INFOPLIST_KEY_CFBundleDisplayName = FitMotion; INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES; INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES; INFOPLIST_KEY_UILaunchScreen_Generation = YES; IPHONEOS_DEPLOYMENT_TARGET = 17.0; MARKETING_VERSION = 1.0; PRODUCT_BUNDLE_IDENTIFIER = com.fitmotion.app; PRODUCT_NAME = "$(TARGET_NAME)"; SWIFT_EMIT_LOC_STRINGS = YES; SWIFT_VERSION = 5.0; TARGETED_DEVICE_FAMILY = 1;}; name = Debug; };
+		B00000000000000000000004 = {isa = XCBuildConfiguration; buildSettings = {ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES; CODE_SIGN_STYLE = Automatic; CURRENT_PROJECT_VERSION = 1; GENERATE_INFOPLIST_FILE = YES; INFOPLIST_KEY_CFBundleDisplayName = FitMotion; INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES; INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES; INFOPLIST_KEY_UILaunchScreen_Generation = YES; IPHONEOS_DEPLOYMENT_TARGET = 17.0; MARKETING_VERSION = 1.0; PRODUCT_BUNDLE_IDENTIFIER = com.fitmotion.app; PRODUCT_NAME = "$(TARGET_NAME)"; SWIFT_EMIT_LOC_STRINGS = YES; SWIFT_VERSION = 5.0; TARGETED_DEVICE_FAMILY = 1;}; name = Release; };
+		B00000000000000000000005 = {isa = XCBuildConfiguration; buildSettings = {BUNDLE_LOADER = "$(TEST_HOST)"; CODE_SIGN_STYLE = Automatic; GENERATE_INFOPLIST_FILE = YES; IPHONEOS_DEPLOYMENT_TARGET = 17.0; PRODUCT_BUNDLE_IDENTIFIER = com.fitmotion.app.tests; PRODUCT_NAME = "$(TARGET_NAME)"; SWIFT_VERSION = 5.0; TARGETED_DEVICE_FAMILY = 1; TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FitMotion.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/FitMotion";}; name = Debug; };
+		B00000000000000000000006 = {isa = XCBuildConfiguration; buildSettings = {BUNDLE_LOADER = "$(TEST_HOST)"; CODE_SIGN_STYLE = Automatic; GENERATE_INFOPLIST_FILE = YES; IPHONEOS_DEPLOYMENT_TARGET = 17.0; PRODUCT_BUNDLE_IDENTIFIER = com.fitmotion.app.tests; PRODUCT_NAME = "$(TARGET_NAME)"; SWIFT_VERSION = 5.0; TARGETED_DEVICE_FAMILY = 1; TEST_HOST = "$(BUILT_PRODUCTS_DIR)/FitMotion.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/FitMotion";}; name = Release; };
+/* End XCBuildConfiguration section */
+/* Begin XCConfigurationList section */
+		A60000000000000000000001 = {isa = XCConfigurationList; buildConfigurations = (B00000000000000000000003, B00000000000000000000004); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+		A60000000000000000000002 = {isa = XCConfigurationList; buildConfigurations = (B00000000000000000000005, B00000000000000000000006); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+		A60000000000000000000003 = {isa = XCConfigurationList; buildConfigurations = (B00000000000000000000001, B00000000000000000000002); defaultConfigurationIsVisible = 0; defaultConfigurationName = Release; };
+/* End XCConfigurationList section */
+ };
+ rootObject = A80000000000000000000001 /* Project object */;
+}

--- a/FitMotion/App/FitMotionApp.swift
+++ b/FitMotion/App/FitMotionApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+@main
+struct FitMotionApp: App {
+    @StateObject private var store = WorkoutStore()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environmentObject(store)
+                .preferredColorScheme(.dark)
+        }
+    }
+}

--- a/FitMotion/Models/Exercise.swift
+++ b/FitMotion/Models/Exercise.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+struct Exercise: Identifiable, Codable, Hashable {
+    let id: String
+    let name: String
+    let muscle: MuscleGroup
+    let equipment: String
+    let instructions: [String]
+    let animationURL: URL?
+    let accent: AccentColor
+
+    enum AccentColor: String, Codable, CaseIterable {
+        case lime, coral, cyan, violet
+    }
+}
+
+enum MuscleGroup: String, Codable, CaseIterable, Identifiable {
+    case fullBody = "Cuerpo completo"
+    case legs = "Piernas"
+    case chest = "Pecho"
+    case back = "Espalda"
+    case core = "Core"
+    case arms = "Brazos"
+
+    var id: String { rawValue }
+}

--- a/FitMotion/Services/ExerciseCatalog.swift
+++ b/FitMotion/Services/ExerciseCatalog.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+enum ExerciseCatalog {
+    private static let assetRoot = "https://cdn.jsdelivr.net/gh/yuhonas/free-exercise-db@main/exercises"
+
+    static let exercises: [Exercise] = [
+        exercise("air-squat", "Sentadilla libre", .legs, "Sin equipo", "Bodyweight_Squat", [
+            "Separa los pies al ancho de los hombros.",
+            "Lleva la cadera hacia atrás manteniendo el pecho elevado.",
+            "Empuja el suelo y vuelve a la posición inicial."
+        ], .lime),
+        exercise("push-up", "Flexiones", .chest, "Sin equipo", "Pushups", [
+            "Apoya las manos ligeramente más abiertas que los hombros.",
+            "Mantén el cuerpo alineado y baja de forma controlada.",
+            "Extiende los brazos sin bloquear los codos."
+        ], .coral),
+        exercise("mountain-climber", "Escaladores", .fullBody, "Sin equipo", "Mountain_Climbers", [
+            "Comienza en plancha alta.",
+            "Acerca una rodilla al pecho y alterna las piernas.",
+            "Mantén la cadera estable durante todo el movimiento."
+        ], .cyan),
+        exercise("plank", "Plancha", .core, "Sin equipo", "Plank", [
+            "Apoya antebrazos y puntas de los pies.",
+            "Activa abdomen y glúteos.",
+            "Conserva una línea recta desde la cabeza hasta los talones."
+        ], .violet),
+        exercise("jumping-jack", "Saltos de tijera", .fullBody, "Sin equipo", "Jumping_Jacks", [
+            "Inicia de pie con los brazos a los lados.",
+            "Salta separando los pies y lleva las manos arriba.",
+            "Regresa suavemente a la posición inicial."
+        ], .lime),
+        exercise("dumbbell-row", "Remo con mancuerna", .back, "Mancuerna", "Dumbbell_Incline_Row", [
+            "Apoya una mano y una rodilla sobre un banco.",
+            "Lleva la mancuerna hacia la cadera.",
+            "Baja el peso lentamente manteniendo la espalda neutra."
+        ], .cyan),
+        exercise("biceps-curl", "Curl de bíceps", .arms, "Mancuernas", "Dumbbell_Bicep_Curl", [
+            "Mantén los codos pegados al torso.",
+            "Flexiona los brazos sin mover los hombros.",
+            "Desciende las mancuernas de forma controlada."
+        ], .coral)
+    ]
+
+    private static func exercise(
+        _ id: String,
+        _ name: String,
+        _ muscle: MuscleGroup,
+        _ equipment: String,
+        _ asset: String,
+        _ instructions: [String],
+        _ accent: Exercise.AccentColor
+    ) -> Exercise {
+        let encoded = asset.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? asset
+        let url = URL(string: "\(assetRoot)/\(encoded)/0.jpg")
+        return Exercise(id: id, name: name, muscle: muscle, equipment: equipment,
+                        instructions: instructions, animationURL: url, accent: accent)
+    }
+}

--- a/FitMotion/ViewModels/WorkoutStore.swift
+++ b/FitMotion/ViewModels/WorkoutStore.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+@MainActor
+final class WorkoutStore: ObservableObject {
+    @Published private(set) var routine: [Exercise]
+    @Published private(set) var favoriteIDs: Set<String>
+
+    private let defaults: UserDefaults
+    private let routineKey = "fitmotion.routine"
+    private let favoritesKey = "fitmotion.favorites"
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        let decoder = JSONDecoder()
+        routine = defaults.data(forKey: routineKey)
+            .flatMap { try? decoder.decode([Exercise].self, from: $0) } ?? []
+        favoriteIDs = Set(defaults.stringArray(forKey: favoritesKey) ?? [])
+    }
+
+    func toggleInRoutine(_ exercise: Exercise) {
+        if let index = routine.firstIndex(of: exercise) {
+            routine.remove(at: index)
+        } else {
+            routine.append(exercise)
+        }
+        persistRoutine()
+    }
+
+    func contains(_ exercise: Exercise) -> Bool { routine.contains(exercise) }
+
+    func toggleFavorite(_ exercise: Exercise) {
+        if favoriteIDs.contains(exercise.id) {
+            favoriteIDs.remove(exercise.id)
+        } else {
+            favoriteIDs.insert(exercise.id)
+        }
+        defaults.set(Array(favoriteIDs), forKey: favoritesKey)
+    }
+
+    func isFavorite(_ exercise: Exercise) -> Bool { favoriteIDs.contains(exercise.id) }
+
+    func removeFromRoutine(at offsets: IndexSet) {
+        for index in offsets.sorted(by: >) { routine.remove(at: index) }
+        persistRoutine()
+    }
+
+    private func persistRoutine() {
+        defaults.set(try? JSONEncoder().encode(routine), forKey: routineKey)
+    }
+}

--- a/FitMotion/Views/ExerciseDetailView.swift
+++ b/FitMotion/Views/ExerciseDetailView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct ExerciseDetailView: View {
+    @EnvironmentObject private var store: WorkoutStore
+    let exercise: Exercise
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 22) {
+                RemoteExerciseMedia(url: exercise.animationURL, tint: .accent(exercise.accent))
+                    .frame(height: 300)
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: 7) {
+                        Text(exercise.name).font(.largeTitle.bold())
+                        Text("\(exercise.muscle.rawValue)  ·  \(exercise.equipment)")
+                            .foregroundStyle(Color.accent(exercise.accent))
+                    }
+                    Spacer()
+                    Button { store.toggleFavorite(exercise) } label: {
+                        Image(systemName: store.isFavorite(exercise) ? "heart.fill" : "heart")
+                            .font(.title2).foregroundStyle(.pink)
+                    }
+                }
+                Text("Cómo hacerlo").font(.title2.bold())
+                ForEach(Array(exercise.instructions.enumerated()), id: \.offset) { index, step in
+                    HStack(alignment: .top, spacing: 14) {
+                        Text("\(index + 1)").font(.headline).foregroundStyle(.black)
+                            .frame(width: 32, height: 32).background(Color.accent(exercise.accent)).clipShape(Circle())
+                        Text(step).foregroundStyle(.white.opacity(0.85)).padding(.top, 5)
+                    }
+                }
+                Button { store.toggleInRoutine(exercise) } label: {
+                    Label(store.contains(exercise) ? "Quitar de mi rutina" : "Agregar a mi rutina",
+                          systemImage: store.contains(exercise) ? "minus" : "plus")
+                    .frame(maxWidth: .infinity).font(.headline).padding()
+                    .foregroundStyle(.black).background(Color.fmLime).clipShape(RoundedRectangle(cornerRadius: 16))
+                }
+            }.padding()
+        }
+        .background(Color.fmBackground.ignoresSafeArea())
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/FitMotion/Views/ExerciseRow.swift
+++ b/FitMotion/Views/ExerciseRow.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct ExerciseRow: View {
+    let exercise: Exercise
+
+    var body: some View {
+        HStack(spacing: 14) {
+            ZStack {
+                Color.accent(exercise.accent).opacity(0.14)
+                Image(systemName: "figure.strengthtraining.traditional")
+                    .font(.title).foregroundStyle(Color.accent(exercise.accent))
+            }
+            .frame(width: 72, height: 72).clipShape(RoundedRectangle(cornerRadius: 18))
+            VStack(alignment: .leading, spacing: 6) {
+                Text(exercise.name).font(.headline).foregroundStyle(.white)
+                Text("\(exercise.muscle.rawValue) · \(exercise.equipment)")
+                    .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+            }
+            Spacer()
+            Image(systemName: "chevron.right").foregroundStyle(.secondary)
+        }
+        .padding(12).background(Color.fmSurface).clipShape(RoundedRectangle(cornerRadius: 22))
+    }
+}

--- a/FitMotion/Views/ExploreView.swift
+++ b/FitMotion/Views/ExploreView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct ExploreView: View {
+    @State private var query = ""
+    @State private var selected: MuscleGroup?
+
+    private var filtered: [Exercise] {
+        ExerciseCatalog.exercises.filter { exercise in
+            (selected == nil || exercise.muscle == selected) &&
+            (query.isEmpty || exercise.name.localizedCaseInsensitiveContains(query))
+        }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                Text("Explorar ejercicios").font(.largeTitle.bold())
+                Text("Encuentra el movimiento ideal para tu objetivo.")
+                    .foregroundStyle(.secondary)
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack {
+                        filterChip("Todos", active: selected == nil) { selected = nil }
+                        ForEach(MuscleGroup.allCases) { group in
+                            filterChip(group.rawValue, active: selected == group) { selected = group }
+                        }
+                    }
+                }
+                LazyVStack(spacing: 12) {
+                    ForEach(filtered) { exercise in
+                        NavigationLink(value: exercise) { ExerciseRow(exercise: exercise) }
+                            .buttonStyle(.plain)
+                    }
+                }
+            }.padding()
+        }
+        .searchable(text: $query, prompt: "Buscar ejercicio")
+        .background(Color.fmBackground.ignoresSafeArea())
+        .navigationDestination(for: Exercise.self) { ExerciseDetailView(exercise: $0) }
+    }
+
+    private func filterChip(_ title: String, active: Bool, action: @escaping () -> Void) -> some View {
+        Button(title, action: action)
+            .font(.subheadline.bold()).foregroundStyle(active ? Color.black : Color.white)
+            .padding(.horizontal, 16).padding(.vertical, 10)
+            .background(active ? Color.fmLime : Color.fmSurface).clipShape(Capsule())
+    }
+}

--- a/FitMotion/Views/HomeView.swift
+++ b/FitMotion/Views/HomeView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+struct HomeView: View {
+    @EnvironmentObject private var store: WorkoutStore
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                header
+                NavigationLink(destination: RoutineView()) {
+                    featuredCard
+                }
+                sectionTitle("Recomendados", subtitle: "Movimientos para empezar hoy")
+                ForEach(ExerciseCatalog.exercises.prefix(3)) { exercise in
+                    NavigationLink(value: exercise) { ExerciseRow(exercise: exercise) }
+                        .buttonStyle(.plain)
+                }
+            }
+            .padding()
+        }
+        .background(Color.fmBackground.ignoresSafeArea())
+        .navigationDestination(for: Exercise.self) { ExerciseDetailView(exercise: $0) }
+        .toolbar(.hidden, for: .navigationBar)
+    }
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("BUEN ENTRENAMIENTO")
+                    .font(.caption.bold()).tracking(1.5).foregroundStyle(.fmLime)
+                Text("¡Vamos a movernos!")
+                    .font(.title.bold())
+            }
+            Spacer()
+            Image(systemName: "bolt.heart.fill")
+                .font(.title2).foregroundStyle(.fmLime)
+                .frame(width: 48, height: 48).background(Color.fmSurface).clipShape(Circle())
+        }
+    }
+
+    private var featuredCard: some View {
+        ZStack(alignment: .bottomLeading) {
+            LinearGradient(colors: [.fmLime.opacity(0.85), .cyan.opacity(0.35), .fmSurface],
+                           startPoint: .topLeading, endPoint: .bottomTrailing)
+            Image(systemName: "figure.run")
+                .font(.system(size: 135, weight: .thin))
+                .foregroundStyle(.white.opacity(0.2)).offset(x: 180, y: -10)
+            VStack(alignment: .leading, spacing: 8) {
+                Label("RUTINA DEL DÍA", systemImage: "flame.fill")
+                    .font(.caption.bold()).tracking(1)
+                Text(store.routine.isEmpty ? "Full body\npara comenzar" : "Tu rutina\nestá lista")
+                    .font(.title.bold()).foregroundStyle(.white)
+                Text(store.routine.isEmpty ? "7 ejercicios · 24 min" : "\(store.routine.count) ejercicios")
+                    .font(.subheadline).foregroundStyle(.white.opacity(0.8))
+                Text("COMENZAR  →").font(.subheadline.bold()).padding(.top, 6)
+            }
+            .padding(22)
+        }
+        .frame(height: 240).clipShape(RoundedRectangle(cornerRadius: 28))
+    }
+
+    private func sectionTitle(_ title: String, subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title).font(.title2.bold())
+            Text(subtitle).font(.subheadline).foregroundStyle(.secondary)
+        }
+    }
+}

--- a/FitMotion/Views/RemoteExerciseMedia.swift
+++ b/FitMotion/Views/RemoteExerciseMedia.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct RemoteExerciseMedia: View {
+    let url: URL?
+    let tint: Color
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 0.7)) { context in
+            let frame = Int(context.date.timeIntervalSinceReferenceDate / 0.7) % 2
+            remoteFrame(url: frameURL(frame))
+        }
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 28))
+        .accessibilityLabel("Demostración animada del ejercicio")
+    }
+
+    @ViewBuilder
+    private func remoteFrame(url: URL?) -> some View {
+        AsyncImage(url: url, transaction: Transaction(animation: .easeInOut(duration: 0.2))) { phase in
+            switch phase {
+            case .success(let image):
+                image.resizable().scaledToFit()
+            case .failure:
+                placeholder(systemName: "wifi.slash")
+            case .empty:
+                ZStack { tint.opacity(0.12); ProgressView().tint(tint) }
+            @unknown default:
+                placeholder(systemName: "figure.strengthtraining.traditional")
+            }
+        }
+    }
+
+    private func frameURL(_ frame: Int) -> URL? {
+        guard let url else { return nil }
+        return URL(string: url.absoluteString.replacingOccurrences(of: "/0.jpg", with: "/\(frame).jpg"))
+    }
+
+    private func placeholder(systemName: String) -> some View {
+        ZStack {
+            tint.opacity(0.12)
+            VStack(spacing: 10) {
+                Image(systemName: systemName).font(.system(size: 54)).foregroundStyle(tint)
+                Text("Vista previa no disponible").font(.caption).foregroundStyle(.secondary)
+            }
+        }
+    }
+}

--- a/FitMotion/Views/RootView.swift
+++ b/FitMotion/Views/RootView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct RootView: View {
+    var body: some View {
+        TabView {
+            NavigationStack { HomeView() }
+                .tabItem { Label("Inicio", systemImage: "house.fill") }
+            NavigationStack { ExploreView() }
+                .tabItem { Label("Explorar", systemImage: "square.grid.2x2.fill") }
+            NavigationStack { RoutineView() }
+                .tabItem { Label("Mi rutina", systemImage: "figure.strengthtraining.traditional") }
+        }
+        .tint(.fmLime)
+    }
+}

--- a/FitMotion/Views/RoutineView.swift
+++ b/FitMotion/Views/RoutineView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct RoutineView: View {
+    @EnvironmentObject private var store: WorkoutStore
+    @State private var showingPlayer = false
+
+    var body: some View {
+        Group {
+            if store.routine.isEmpty { emptyState } else { routineList }
+        }
+        .background(Color.fmBackground.ignoresSafeArea())
+        .navigationTitle("Mi rutina")
+        .fullScreenCover(isPresented: $showingPlayer) { WorkoutPlayerView(exercises: store.routine) }
+    }
+
+    private var routineList: some View {
+        VStack(spacing: 14) {
+            List {
+                Section("\(store.routine.count) ejercicios · 40 s cada uno") {
+                    ForEach(store.routine) { ExerciseRow(exercise: $0).listRowBackground(Color.clear) }
+                        .onDelete(perform: store.removeFromRoutine)
+                }
+            }
+            .scrollContentBackground(.hidden).listStyle(.plain)
+            Button { showingPlayer = true } label: {
+                Label("Comenzar entrenamiento", systemImage: "play.fill")
+                    .frame(maxWidth: .infinity).padding().font(.headline)
+                    .foregroundStyle(.black).background(Color.fmLime).clipShape(RoundedRectangle(cornerRadius: 16))
+            }.padding([.horizontal, .bottom])
+        }
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label("Tu rutina está vacía", systemImage: "figure.cooldown")
+        } description: {
+            Text("Explora ejercicios y agrega tus favoritos para comenzar.")
+        }
+    }
+}

--- a/FitMotion/Views/Theme.swift
+++ b/FitMotion/Views/Theme.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+extension Color {
+    static let fmBackground = Color(red: 0.035, green: 0.047, blue: 0.055)
+    static let fmSurface = Color(red: 0.075, green: 0.09, blue: 0.10)
+    static let fmLime = Color(red: 0.72, green: 0.96, blue: 0.20)
+
+    static func accent(_ value: Exercise.AccentColor) -> Color {
+        switch value {
+        case .lime: .fmLime
+        case .coral: Color(red: 1, green: 0.39, blue: 0.34)
+        case .cyan: Color(red: 0.18, green: 0.83, blue: 0.93)
+        case .violet: Color(red: 0.66, green: 0.48, blue: 1)
+        }
+    }
+}

--- a/FitMotion/Views/WorkoutPlayerView.swift
+++ b/FitMotion/Views/WorkoutPlayerView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct WorkoutPlayerView: View {
+    @Environment(\.dismiss) private var dismiss
+    let exercises: [Exercise]
+    @State private var index = 0
+    @State private var seconds = 40
+    @State private var paused = false
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    private var current: Exercise { exercises[index] }
+
+    var body: some View {
+        ZStack {
+            Color.fmBackground.ignoresSafeArea()
+            VStack(spacing: 22) {
+                HStack {
+                    Button("Cerrar") { dismiss() }.foregroundStyle(.secondary)
+                    Spacer()
+                    Text("\(index + 1) / \(exercises.count)").font(.headline)
+                    Spacer()
+                    Color.clear.frame(width: 45)
+                }
+                ProgressView(value: Double(index * 40 + 40 - seconds), total: Double(exercises.count * 40))
+                    .tint(.fmLime)
+                Spacer()
+                RemoteExerciseMedia(url: current.animationURL, tint: .accent(current.accent))
+                    .frame(maxHeight: 350)
+                Text(current.name).font(.largeTitle.bold()).multilineTextAlignment(.center)
+                Text("00:\(String(format: "%02d", seconds))")
+                    .font(.system(size: 54, weight: .bold, design: .rounded)).foregroundStyle(.fmLime)
+                HStack(spacing: 35) {
+                    Button { previous() } label: { Image(systemName: "backward.fill") }
+                        .disabled(index == 0)
+                    Button { paused.toggle() } label: {
+                        Image(systemName: paused ? "play.fill" : "pause.fill")
+                            .font(.title).frame(width: 72, height: 72).background(Color.fmLime)
+                            .foregroundStyle(.black).clipShape(Circle())
+                    }
+                    Button { next() } label: { Image(systemName: "forward.fill") }
+                        .disabled(index == exercises.count - 1)
+                }.font(.title2).foregroundStyle(.white)
+                Spacer()
+            }.padding()
+        }
+        .onReceive(timer) { _ in
+            guard !paused else { return }
+            if seconds > 0 { seconds -= 1 } else if index < exercises.count - 1 { next() } else { paused = true }
+        }
+    }
+
+    private func next() { guard index < exercises.count - 1 else { return }; index += 1; seconds = 40 }
+    private func previous() { guard index > 0 else { return }; index -= 1; seconds = 40 }
+}

--- a/FitMotionTests/WorkoutStoreTests.swift
+++ b/FitMotionTests/WorkoutStoreTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import FitMotion
+
+@MainActor
+final class WorkoutStoreTests: XCTestCase {
+    func testRoutineAndFavoritesPersist() {
+        let suite = "WorkoutStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let exercise = ExerciseCatalog.exercises[0]
+        let store = WorkoutStore(defaults: defaults)
+
+        store.toggleInRoutine(exercise)
+        store.toggleFavorite(exercise)
+
+        let restored = WorkoutStore(defaults: defaults)
+        XCTAssertTrue(restored.contains(exercise))
+        XCTAssertTrue(restored.isFavorite(exercise))
+    }
+
+    func testTogglingRoutineRemovesExistingExercise() {
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let store = WorkoutStore(defaults: defaults)
+        let exercise = ExerciseCatalog.exercises[0]
+        store.toggleInRoutine(exercise)
+        store.toggleInRoutine(exercise)
+        XCTAssertTrue(store.routine.isEmpty)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# computacion_movil_rep01
+# FitMotion
+
+Aplicación iOS de rutinas de ejercicio construida con SwiftUI. Permite explorar
+ejercicios, filtrarlos por grupo muscular, armar una rutina y seguirla con un
+temporizador. Cada ejercicio anima los fotogramas remotos del repositorio y conserva una
+presentación de respaldo si la red no está disponible.
+
+## Requisitos
+
+- Xcode 16 o posterior
+- iOS 17 o posterior
+
+## Ejecutar
+
+1. Abre `FitMotion.xcodeproj` en Xcode.
+2. Selecciona un simulador de iPhone.
+3. Presiona **Run** (`⌘R`).
+
+No se necesitan claves de API. Las animaciones de demostración se sirven desde
+el repositorio público `yuhonas/free-exercise-db` mediante jsDelivr. Para un
+producto en producción se recomienda fijar una versión del repositorio o alojar
+los recursos en infraestructura propia.
+
+## Arquitectura
+
+- `Models`: entidades de ejercicio y rutina.
+- `Services`: catálogo y persistencia local con `UserDefaults`.
+- `ViewModels`: estado observable de la rutina.
+- `Views`: interfaz SwiftUI y reproductor de fotogramas con `AsyncImage` y `TimelineView`.
+
+Los favoritos y la rutina se guardan en el dispositivo. El catálogo de ejemplo
+queda disponible sin conexión; únicamente las imágenes animadas requieren red.


### PR DESCRIPTION
### Motivation
- Proveer una aplicación iOS que permita explorar ejercicios, reproducir animaciones desde un repositorio de GIFs/fotogramas y crear/seguir rutinas de entrenamiento.
- Usar un catálogo público de ejercicios como fuente de las animaciones remotas para demostrar la integración con recursos externos.
- Ofrecer persistencia local de favoritos y rutinas para uso sin cuenta ni servidor.

### Description
- Añade la app SwiftUI `FitMotion` con entrada `FitMotionApp` y navegación por pestañas (`RootView`, `HomeView`, `ExploreView`, `RoutineView`).
- Implementa modelos y catálogo (`Exercise`, `MuscleGroup`, `ExerciseCatalog`) que apuntan a fotogramas remotos en `yuhonas/free-exercise-db` (vía jsDelivr) y normaliza URLs de fotogramas. 
- Añade `WorkoutStore` con persistencia en `UserDefaults` y operaciones para toggling de rutina y favoritos, y pruebas unitarias en `FitMotionTests/WorkoutStoreTests.swift` que verifican persistencia y comportamiento de toggle.
- Implementa vistas para detalle y lista de ejercicios (`ExerciseRow`, `ExerciseDetailView`) y un reproductor de entrenamiento (`WorkoutPlayerView`) con temporizador, pausa, navegación y progreso.
- Implementa reproducción animada de fotogramas remotos usando `TimelineView` + `AsyncImage` en `RemoteExerciseMedia` con placeholder y manejo de ausencia de red; también incluye recursos visuales y tema (`Theme.swift`).
- Añade fichero `project.pbxproj` para facilitar apertura en Xcode y actualiza `README.md` con requisitos, ejecución y arquitectura.

### Testing
- Ejecuté `swiftc -parse $(find FitMotion -name '*.swift' -print | sort)` y la verificación de sintaxis fue satisfactoria.
- Ejecuté `git diff --check` para comprobar problemas de espacio en blanco y no se detectaron errores.
- Se validó programáticamente la estructura y el balance de llaves del archivo `FitMotion.xcodeproj/project.pbxproj` y la presencia de las referencias Swift esperadas.
- La comprobación HTTP de los assets remotos mediante `curl` fue bloqueada por el proxy del entorno (HTTP 403), y `xcodebuild` no pudo ejecutarse porque el entorno es Linux sin Xcode; la app contempla el caso sin red mostrando una vista de respaldo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a679d8c250483248182a405affa51da)